### PR TITLE
fix: replace deprecated np.bool usage and update dependencies

### DIFF
--- a/DeTRC/utill/misc.py
+++ b/DeTRC/utill/misc.py
@@ -344,7 +344,7 @@ def nested_tensor_from_tensor_list(tensor_list, clip_len=None, snippet_num=None)
         dtype = tensor_list[0][0].dtype
         tensor = torch.zeros(batch_shape, dtype=dtype)
         mask = torch.ones((bz, max_clip_num, clip_len), dtype=torch.bool)
-        clip_mask = np.ones((bz, max_clip_num), dtype=np.bool)
+        clip_mask = np.ones((bz, max_clip_num), dtype=np.bool_)
         snippets_pad = torch.ones((bz, max_clip_num)) * -1
 
         for feat, pad_feat, m, clip_m, snip, snip_pad in zip(
@@ -381,7 +381,7 @@ def nested_tensor_from_tensor_list(tensor_list, clip_len=None, snippet_num=None)
         dtype = tensor_list[0].dtype
         tensor = torch.zeros(batch_shape, dtype=dtype)
         mask = torch.ones((bz, max_clip_num, clip_len), dtype=torch.bool)
-        clip_mask = np.ones((bz, max_clip_num), dtype=np.bool)
+        clip_mask = np.ones((bz, max_clip_num), dtype=np.bool_)
         snippets_pad = torch.ones((bz, max_clip_num)) * -1
 
         for feat, pad_feat, m, clip_m, snip, snip_pad in zip(
@@ -567,23 +567,6 @@ def interpolate(
         )
 
 
-@torch.no_grad()
-def accuracy(output, target, topk=(1,)):
-    """Computes the precision@k for the specified values of k"""
-    if target.numel() == 0:
-        return [torch.zeros([], device=output.device)]
-    maxk = max(topk)
-    batch_size = target.size(0)
-
-    _, pred = output.topk(maxk, 1, True, True)
-    pred = pred.t()
-    correct = pred.eq(target.view(1, -1).expand_as(pred))
-
-    res = []
-    for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0)
-        res.append(correct_k.mul_(100.0 / batch_size))
-    return res
 
 
 def inverse_sigmoid(x, eps=1e-5):

--- a/README.md
+++ b/README.md
@@ -18,15 +18,11 @@ This is the official PyTorch implementation of the paper "Efficient Action Count
 
 
 ## Installation
-We build our code based on the MMaction2 project (1.3.10 version). See [here](https://github.com/open-mmlab/mmaction2) for more details if you are interested.
-MMCV is needed before install MMaction2, which can be install with:
+We build our code based on the MMaction2 project (1.3.10 version). See [here](https://github.com/open-mmlab/mmaction2) for more details if you are interested. Install the runtime dependencies with:
 ```shell
-pip install mmcv-full-f https://download.openmmlab.com/mmcv/dist/{cu_version}/{torch_version}/index.html
-# For example, to install the latest mmcv-full with CUDA 11.1 and PyTorch 1.9.0, use the following command:
-pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html
+pip install -r requirements.txt
 ```
-For other CUDA or pytorch version, please refer to [mmcv](https://github.com/open-mmlab/mmcv).
-
+If you need a specific CUDA or PyTorch build for `mmcv-full`, please refer to the [mmcv](https://github.com/open-mmlab/mmcv) documentation.
 
 Then, our code can be built by
 ```shell

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -r requirements/build.txt
+-r requirements/mminstall.txt
 -r requirements/optional.txt
 -r requirements/runtime.txt
 -r requirements/tests.txt

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -5,3 +5,8 @@ numpy
 opencv-contrib-python
 Pillow
 scipy
+pandas
+scikit-learn
+torch>=1.3
+torchvision
+mmcv-full>=1.3.1

--- a/tools/misc/evaluation/mean_ap.py
+++ b/tools/misc/evaluation/mean_ap.py
@@ -179,8 +179,8 @@ def tpfp_default(det_segments,
     """
     # an indicator of ignored gts
     gt_ignore_inds = np.concatenate(
-        (np.zeros(gt_segments.shape[0], dtype=np.bool),
-         np.ones(gt_segments_ignore.shape[0], dtype=np.bool)))
+        (np.zeros(gt_segments.shape[0], dtype=np.bool_),
+         np.ones(gt_segments_ignore.shape[0], dtype=np.bool_)))
     # stack gt_segments and gt_segments_ignore for convenience
     gt_segments = np.vstack((gt_segments, gt_segments_ignore))
 


### PR DESCRIPTION
## Summary
- replace removed `np.bool` with `np.bool_`
- drop duplicated accuracy function
- document and add missing runtime dependencies for easier installation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: file or directory not found: tests/)*

------
https://chatgpt.com/codex/tasks/task_e_68ad865557d88333bbdac55da645e400