### PR TITLE
Fix dataset type check in load_video_length_dict

### DIFF
--- a/DeTRC/repcount_dataset.py
+++ b/DeTRC/repcount_dataset.py
@@ -129,7 +129,7 @@ def load_proposal_file(filename):
 def load_video_length_dict(dataset_type):
     if dataset_type == "Repcount":
         length_file = "./datasets/Repcount.json"
-    elif length_file == "UCFRep":
+    elif dataset_type == "UCFRep":
         length_file = "./datasets/UCFRep.json"
     else:
         raise Exception("not implement for this dataset type, please check.")


### PR DESCRIPTION
## Summary
- fix incorrect variable name when selecting UCFRep dataset

## Testing
- `python -m py_compile DeTRC/repcount_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad95fe861083339b76671707be3548