### PR TITLE
fix: replace deprecated np.int

### DIFF
--- a/DeTRC/utill/temporal_box_producess.py
+++ b/DeTRC/utill/temporal_box_producess.py
@@ -18,7 +18,7 @@ def mid_dis2start_end(x):
 def start_end2mid_dis(x):
     # x shape (num_seg, 2)
     s, e = x[:, 0], x[:, 1]
-    b = [((s + e) / 2).astype(np.int), (e - s).astype(np.int)]
+    b = [((s + e) / 2).astype(np.int64), (e - s).astype(np.int64)]
     return np.stack(b)
 
 


### PR DESCRIPTION
## Summary
- replace deprecated `np.int` with `np.int64` in temporal box processing utility

## Testing
- `python -m py_compile DeTRC/utill/temporal_box_producess.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad960299f483339151da53ec3795b0