### PR TITLE
Fix count parsing in load_proposal_file

### DIFF
--- a/DeTRC/repcount_dataset.py
+++ b/DeTRC/repcount_dataset.py
@@ -107,7 +107,7 @@ def load_proposal_file(filename):
             # cls = fix_and_get_label(rows["type"])
             # if cls == -1:
             #     return
-            count = int(rows["count"]) if pd.notna("count") else 0
+            count = int(rows["count"]) if pd.notna(rows["count"]) else 0
             if "total_frames" in rows:
                 n_frames = int(rows["total_frames"])
             else:


### PR DESCRIPTION
## Summary
- ensure missing `count` values default to 0 when loading proposals

## Testing
- `pytest` *(fails: file or directory not found)*
- `python - <<'PY'
import ast
import pandas as pd
with open('DeTRC/repcount_dataset.py','r') as f:
    src=f.read()
import ast
module=ast.parse(src)
for node in module.body:
    if isinstance(node, ast.FunctionDef) and node.name=='load_proposal_file':
        func_node=node
        break
start,end=func_node.lineno-1, func_node.end_lineno
lines=src.splitlines()
code='\n'.join(lines[start:end])
namespace={'pd':pd}
exec(code,namespace)
load_proposal_file=namespace['load_proposal_file']
open('temp2.csv','w').write('name,count,total_frames,a,b,c,d,e,f\nvideo1.mp4,1,100,0,1,2,3,4,5\nvideo2.mp4,,200,0,1,2,3,4,5\n')
print(load_proposal_file('temp2.csv'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ad9d72012c8333b34a03e38d4c0391